### PR TITLE
True mean calculation and testing for all aggregation functions

### DIFF
--- a/elsasserlib/R/bwtools.R
+++ b/elsasserlib/R/bwtools.R
@@ -223,7 +223,6 @@ aggregate_scores <- function(scored.gr, group.col, aggregate.by) {
     if (aggregate.by == 'true_mean') {
        # Multiply each score by interval length
        score.cols <- colnames(mcols(scored.gr))
-
        score.cols <- score.cols[!score.cols %in% c(group.col)]
 
        sum.vals <- df[, score.cols]*df$length
@@ -252,5 +251,7 @@ aggregate_scores <- function(scored.gr, group.col, aggregate.by) {
     }
 
     as.data.frame(df)
+  } else {
+    stop("Grouping column not provided or not present in GRanges object.")
   }
 }

--- a/elsasserlib/R/bwtools.R
+++ b/elsasserlib/R/bwtools.R
@@ -197,6 +197,17 @@ bw_ranges <- function (bwfile, gr, per.locus.stat='mean', selection=NULL) {
   result
 }
 
+validate_categories <- function(cat.values) {
+  MAX_CATEGORIES <- 50
+  # Test number of values in group.col
+  ncat <- length(levels(as.factor(cat.values)))
+  if (ncat > MAX_CATEGORIES) {
+    warning(paste("Number of values in group column field very large:",
+                  ncat,
+                  "(does BED file have unique IDs instead of categories?)"))
+  }
+}
+
 #'
 #' Aggregate scores of a GRanges object on a specific field
 #'
@@ -215,10 +226,12 @@ bw_ranges <- function (bwfile, gr, per.locus.stat='mean', selection=NULL) {
 #' @importFrom rtracklayer mcols
 aggregate_scores <- function(scored.gr, group.col, aggregate.by) {
   if ( !is.null(group.col) && group.col %in% names(mcols(scored.gr))) {
+
     # GRanges objects are 1-based and inclusive [start, end]
     scored.gr$length <- end(scored.gr) - start(scored.gr) + 1
 
     df <- data.frame(mcols(scored.gr))
+    validate_categories(df[, group.col])
 
     if (aggregate.by == 'true_mean') {
        # Multiply each score by interval length

--- a/elsasserlib/R/bwtools.R
+++ b/elsasserlib/R/bwtools.R
@@ -203,18 +203,54 @@ bw_ranges <- function (bwfile, gr, per.locus.stat='mean', selection=NULL) {
 #' Aggregates scores of a GRanges object on a specific field.
 #' @param scored.gr A GRanges object with numerical metadata columns
 #' @param group.col A column among the mcols that can be seen as a factor.
-#' @param aggregate.by Function used to aggregate (mean, median, any valid
-#'     function).
+#' @param aggregate.by Function used to aggregate: mean, median, true_mean.
+#'     true_mean: Mean coverage taking all elements in a class as one large bin
+#'     mean: mean-of-distribution approach. The mean of the aggregated value per
+#'       locus is reported.
+#'     median: median-of-distribution. The median of the aggregated value per
+#'       locus is reported
 #' @return A DataFrame with the aggregated scores (any numerical column will be
 #'     aggregated).
 #' @importFrom dplyr group_by_at summarise across `%>%`
 #' @importFrom rtracklayer mcols
 aggregate_scores <- function(scored.gr, group.col, aggregate.by) {
-  df <- data.frame(mcols(scored.gr))
   if ( !is.null(group.col) && group.col %in% names(mcols(scored.gr))) {
-    df <- df %>%
-      group_by_at(group.col) %>%
-      summarise(across(where(is.numeric), aggregate.by))
+    # GRanges objects are 1-based and inclusive [start, end]
+    scored.gr$length <- end(scored.gr) - start(scored.gr) + 1
+
+    df <- data.frame(mcols(scored.gr))
+
+    if (aggregate.by == 'true_mean') {
+       # Multiply each score by interval length
+       score.cols <- colnames(mcols(scored.gr))
+
+       score.cols <- score.cols[!score.cols %in% c(group.col)]
+
+       sum.vals <- df[, score.cols]*df$length
+       colnames(sum.vals) <- score.cols
+       sum.vals[, group.col] <- df[, group.col]
+       sum.vals$length <- df$length
+
+       # Summarize SUM only
+       sum.vals <- sum.vals %>%
+         group_by_at(group.col) %>%
+         summarise(across(where(is.numeric), sum))
+
+       # Divide sum(scores) by sum(length) and keep only scores
+       df <- sum.vals[, score.cols]/sum.vals$length
+       df[, group.col] <- sum.vals[, group.col]
+       df <- df[, c(score.cols, group.col)]
+
+    } else if (aggregate.by %in% c('mean', 'median')) {
+      f <- get(aggregate.by)
+      df <- df %>%
+        group_by_at(group.col) %>%
+        summarise(across(where(is.numeric), f))
+
+    } else {
+      stop(paste("Function not implemented as aggregate.by:", aggregate.by))
+    }
+
+    as.data.frame(df)
   }
-  as.data.frame(df)
 }

--- a/elsasserlib/tests/testthat/test_bwtools.R
+++ b/elsasserlib/tests/testthat/test_bwtools.R
@@ -18,12 +18,12 @@ toy_example <- function(bw1, bw2, bed_with_names) {
   )
 
   labeled_gr <- GRanges(
-    seqnames = c('chr1', 'chr1', 'chr2', 'chr2'),
-    ranges = IRanges(c(21,  61, 21, 111),
-                     c(40, 100, 40, 130))
+    seqnames = c('chr1', 'chr1', 'chr2', 'chr2', 'chr2'),
+    ranges = IRanges(c(21,  61, 21, 111, 161),
+                     c(40, 100, 40, 130, 180))
   )
 
-  labeled_gr$name <- c('typeA', 'typeB', 'typeA', 'typeB')
+  labeled_gr$name <- c('typeA', 'typeB', 'typeA', 'typeB', 'typeB')
 
   chromsizes <- c(200,200)
 
@@ -34,10 +34,6 @@ toy_example <- function(bw1, bw2, bed_with_names) {
   export(gr, bw1)
   export(gr2, bw2)
   export(labeled_gr, bed_with_names)
-
-  # tiles <- tileGenome(c(chr1=200,chr2=200),
-  #                     tilewidth=20,
-  #                     cut.last.tile.in.chrom=T)
 
 }
 
@@ -178,18 +174,52 @@ test_that("bw_bed crashes on wrong number of colnames for multiple files", {
 
 })
 
-test_that("bw_bed returns correct aggregated values", {
+test_that("bw_bed returns correct mean-of-means aggregated values", {
   values <- bw_bed(bw1,
                    bed_with_names,
                    colnames='bw1',
                    per.locus.stat='mean',
-                   aggregate.by=mean)
+                   aggregate.by='mean')
 
   expect_is(values, 'data.frame')
   expect_equal(values[values$name=='typeA', 'bw1'], 7)
-  expect_equal(values[values$name=='typeB', 'bw1'], 10.5)
+  expect_equal(values[values$name=='typeB', 'bw1'], 13.3333333333)
 })
+
+test_that("bw_bed returns correct true_mean aggregated values", {
+  values <- bw_bed(bw1,
+                   bed_with_names,
+                   colnames='bw1',
+                   per.locus.stat='mean',
+                   aggregate.by='true_mean')
+
+  expect_is(values, 'data.frame')
+  expect_equal(values[values$name=='typeA', 'bw1'], 7)
+  expect_equal(values[values$name=='typeB', 'bw1'], 11.125)
+})
+
+test_that("bw_bed returns correct median-of-means aggregated values", {
+  values <- bw_bed(bw1,
+                   bed_with_names,
+                   colnames='bw1',
+                   per.locus.stat='mean',
+                   aggregate.by='median')
+
+  expect_is(values, 'data.frame')
+  expect_equal(values[values$name=='typeA', 'bw1'], 7)
+  expect_equal(values[values$name=='typeB', 'bw1'], 16.5)
+})
+
 
 test_that("build_bins crashes on unknown or not included genome", {
   expect_error(build_bins(bsize=10000, genome='mm10'))
 })
+
+test_that("bw_bed throws error on not implemented aggregate.by", {
+  expect_error(values <- bw_bed(bw1,
+                                bed_with_names,
+                                colnames='bw1',
+                                per.locus.stat='mean',
+                                aggregate.by='max'))
+})
+

--- a/elsasserlib/vignettes/bw-tools.Rmd
+++ b/elsasserlib/vignettes/bw-tools.Rmd
@@ -127,7 +127,7 @@ summary.score <- bw_bed(bw.file,
                         bed.file,
                         colnames=c('score'),
                         per.locus.stat = "mean",
-                        aggregate.by=mean)
+                        aggregate.by="mean")
 
 # We get a GRanges object which one score per locus
 summary.score
@@ -144,10 +144,28 @@ those, to avoid influence of outliers:
 median.score <- bw_bed(bw.file,
                        bed.file,
                        per.locus.stat="mean",
-                       aggregate.by=median)
+                       aggregate.by="median")
 
 # We get a GRanges object which one score group of loci
 median.score
+```
+
+Note as well that this `mean` value is a `mean-of-means` or aggregated values
+if `per.locus.stat` is a different value. If you want a pooled mean as if all
+loci corresponding to a category were a single bin, you want to use `true_mean`.
+This behavior is the same as the one obtained with `bwtool` with `-total` 
+parameter on.
+
+```{r} 
+# We intersect these two files
+summary.score <- bw_bed(bw.file,
+                        bed.file,
+                        colnames=c('score'),
+                        per.locus.stat = "mean",
+                        aggregate.by="true_mean")
+
+# We get a GRanges object which one score per locus
+summary.score
 ```
 
 With this info you could already have an idea of which loci groups have more


### PR DESCRIPTION
`aggregate.by` parameter is now a string, not a function, for consistency with `per.locus.stat` (fixes #23).

It accepts now three options: `mean`,  `true_mean`, `median`. Now `true_mean` is also calculated the same way as bwtool does (pooling all the lengths and calculating true pile up). This partially resolves #24, even though default `aggregate.by` needs to be `NULL`, as the default behavior is **not to** aggregate, just report `mean` coverage per locus.

**NOTE**: A slight difference in rounding could be found for `true_mean` compared to `bwtool`, because `rtracklayer` gives me the mean per locus, I calculate multiplying this value by interval length, so some decimal places could change depending on precision.

Added also testing for number of categories in the `name` field of the BED file provided if `aggregate.by` is used. It will throw a warning if a reasonably high number of different values is found (I set this to 50). This helps identify when we are trying to aggregate values that are coming from a `BED` file that has unique IDs instead of categories.

