### PR TITLE
aggregating fix

### DIFF
--- a/elsasserlib/R/bwtools.R
+++ b/elsasserlib/R/bwtools.R
@@ -257,7 +257,7 @@ aggregate_scores <- function(scored.gr, group.col, aggregate.by) {
   if ( !is.null(group.col) && group.col %in% names(mcols(scored.gr))) {
 
     # GRanges objects are 1-based and inclusive [start, end]
-    scored.gr$length <- end(scored.gr) - start(scored.gr) + 1
+    scored.gr$length <- GenomicRanges::end(scored.gr) - GenomicRanges::start(scored.gr) + 1
 
     df <- data.frame(mcols(scored.gr))
     validate_categories(df[, group.col])


### PR DESCRIPTION
Fix for `bw_bed` aggregating problem. I have not been able to reproduce the error in a test case, though. It seems that in some cases, functions `start` and `end` were not taken from `GenomicRanges`, so the output was unexpected.

Fixes #32 