### PR TITLE
file input explicitly tested

### DIFF
--- a/elsasserlib/DESCRIPTION
+++ b/elsasserlib/DESCRIPTION
@@ -41,7 +41,7 @@ Imports:
   scales
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Suggests: 
     knitr,
     testthat

--- a/elsasserlib/R/bwtools.R
+++ b/elsasserlib/R/bwtools.R
@@ -24,12 +24,10 @@ bw_bins <- function(bwfiles,
                     genome='mm9',
                     selection=NULL) {
 
+  check_filelist(bwfiles)
+
   if (is.null(colnames)) {
     colnames <- basename(bwfiles)
-  }
-
-  if (length(bwfiles) != length(colnames)) {
-    stop("BigWig file list and column names must have the same length.")
   }
 
   tiles <- build_bins(bsize=bsize, genome=genome)
@@ -59,6 +57,10 @@ multi_bw_ranges <- function(bwfilelist,
                             gr,
                             per.locus.stat='mean',
                             selection=NULL) {
+
+  if (length(bwfilelist) != length(colnames)) {
+    stop("BigWig file list and column names must have the same length.")
+  }
 
   summaries <- purrr::map(bwfilelist,
                           bw_ranges,
@@ -119,12 +121,11 @@ bw_bed <- function(bwfiles,
                    per.locus.stat='mean',
                    aggregate.by=NULL) {
 
+  check_filelist(bwfiles)
+  check_filelist(bedfile)
+
   if (is.null(colnames)) {
     colnames <- basename(bwfiles)
-  }
-
-  if (length(bwfiles) != length(colnames)) {
-    stop("BigWig file list and column names must have the same length.")
   }
 
   bed <- import(bedfile)
@@ -147,6 +148,17 @@ bw_bed <- function(bwfiles,
     result <- natural_sort_by_field(df, 'name')
   }
   result
+}
+
+check_filelist <- function(filelist) {
+  if (length(filelist) == 0) {
+    stop("File list provided is empty.")
+  }
+
+  if (!all(file.exists(filelist))) {
+    msg <- paste("Files not found:", filelist[!file.exists(filelist)])
+    stop(msg)
+  }
 }
 
 #' Moves a column of a dataframe to rownames and naturally sorts the rows

--- a/elsasserlib/tests/testthat/test_bwtools.R
+++ b/elsasserlib/tests/testthat/test_bwtools.R
@@ -209,6 +209,34 @@ test_that("bw_bed returns correct true_mean aggregated values", {
   expect_equal(values['typeB', 'bw1'], 11.125)
 })
 
+test_that("bw_bed on an empty list throws an error", {
+  expect_error({ values <- bw_bed(c(),
+                   bed_with_names,
+                   per.locus.stat='mean',
+                   aggregate.by='true_mean')},
+               "File list provided is empty."
+  )
+
+})
+
+test_that("bw_bed on non-existing bed file throws an error", {
+  expect_error({ values <- bw_bed(bw1,
+                                  'invalidname.bed',
+                                  per.locus.stat='mean',
+                                  aggregate.by='true_mean')},
+               "Files not found: invalidname.bed"
+  )
+})
+
+test_that("bw_bed errors on non existing files on bwlist", {
+  expect_error({ values <- bw_bed(c(bw1, 'invalidname.bw'),
+                                  bed_with_names,
+                                  per.locus.stat='mean',
+                                  aggregate.by='true_mean')},
+               "Files not found: invalidname.bw"
+  )
+})
+
 test_that("bw_bed returns correct median-of-means aggregated values", {
   values <- bw_bed(bw1,
                    bed_with_names,


### PR DESCRIPTION
Now inputs for `bw_bed` and `bw_bins` are explicitly tested for file existence, so the error you get is more intuitive. Unit tests have been included for this.

fixes #42 