### PR TITLE
Bigwig profile over BED functionality

### DIFF
--- a/elsasserlib/tests/testthat/test_bwtools.R
+++ b/elsasserlib/tests/testthat/test_bwtools.R
@@ -41,7 +41,7 @@ toy_example <- function(bw1, bw2, bw_special, bed_with_names) {
 
 bw1 <- tempfile('bigwig', fileext='.bw')
 bw2 <- tempfile('bigwig', fileext='.bw')
-bw_special <- tempfile('big-wig', fileext='.bw')
+bw_special <- tempfile('bigwig', fileext='.bw')
 bed_with_names <-tempfile('bed', fileext='.bed')
 
 setup(toy_example(bw1, bw2, bw_special, bed_with_names))
@@ -219,6 +219,15 @@ test_that("bw_bed on an empty list throws an error", {
 
 })
 
+test_that("bw_profile on an empty list throws an error", {
+  expect_error({ values <- bw_profile(c(),
+                                      bed_with_names,
+                                      colnames=NULL)},
+               "File list provided is empty."
+  )
+
+})
+
 test_that("bw_bed on non-existing bed file throws an error", {
   expect_error({ values <- bw_bed(bw1,
                                   'invalidname.bed',
@@ -228,6 +237,15 @@ test_that("bw_bed on non-existing bed file throws an error", {
   )
 })
 
+test_that("bw_profile on non-existing bed file throws an error", {
+  expect_error({ values <- bw_profile(bw1,
+                                  'invalidname.bed',
+                                  colnames=NULL)},
+               "Files not found: invalidname.bed"
+  )
+})
+
+
 test_that("bw_bed errors on non existing files on bwlist", {
   expect_error({ values <- bw_bed(c(bw1, 'invalidname.bw'),
                                   bed_with_names,
@@ -236,6 +254,22 @@ test_that("bw_bed errors on non existing files on bwlist", {
                "Files not found: invalidname.bw"
   )
 })
+
+
+test_that("bw_profile errors on non existing files on bwlist", {
+  expect_error({ values <- bw_profile(c(bw1, 'invalidname.bw'),
+                                      bed_with_names,
+                                      colnames=NULL)},
+               "Files not found: invalidname.bw"
+  )
+})
+
+
+test_that("bw_profile runs quiet on valid parameters", {
+  expect_silent({values <- bw_profile(c(bw1), bed_with_names, colnames=NULL)})
+
+})
+
 
 test_that("bw_bed returns correct median-of-means aggregated values", {
   values <- bw_bed(bw1,


### PR DESCRIPTION
Having operations with `bigWig` files we usually perform all in the same place can be of use. So now there is a `bw_profile` function that takes a list of `bigWig` files and a `BED` file and computes the values according to bin size, and mode. Mode can be `stretch`, `start`, `end` and `center`. This is adapted from `seqplots` wrapping code of rtracklayer functions that summarize `bigWig` files over sets of `BED` files. 

As a difference, the pseudolength for the `stretch` mode is not provided as a parameter but calculated as the median of the lengths of the loci provided in the `BED` file. Additionally, the summary matrix is using the upper level `rtracklayer` function `summary` instead of calling C code underneath, which is not part of the API and may be subject to change by their developers. This should not damage efficiency, since the code executed underneath is still the same function.

The rest of the parameters remain the same as you would run in seqplots: `upstream`, `downstream`, `bin` (binsize), `ignore_strand`.

This function returns a data frame object in long format, so it's quite straightforward to plot the profile with `ggplot`. 

Further functionality for including norm to input profiles and so on could be included, since now we have data structures with the actual values on the profile.

Related to #39. However, plotting functions are not yet provided. I intend to include a few soon.

