### PR TITLE
bw_profile parameter fix

### DIFF
--- a/elsasserlib/R/bwtools.R
+++ b/elsasserlib/R/bwtools.R
@@ -342,6 +342,7 @@ calculate_bw_profile <- function(bw,
                                  downstream=2500,
                                  ignore_strand=F) {
 
+
   bwfile <- BigWigFile(path=bw)
   if (is.null(label)) {
     label <- basename(bw)
@@ -353,7 +354,6 @@ calculate_bw_profile <- function(bw,
     # Stretch to the median value of the GR object
     middle_npoints <- floor(median(GenomicRanges::width(gr))/bin )
 
-    # So beautiful
     left <- summary_matrix(bwfile,
                            GenomicRanges::flank(gr, upstream, start=TRUE),
                            npoints=left_npoints,
@@ -405,7 +405,7 @@ calculate_bw_profile <- function(bw,
 #' @export
 bw_profile <- function(bwfiles,
                        bedfile,
-                       colnames,
+                       colnames=NULL,
                        mode='stretch',
                        bin=100,
                        upstream=2500,
@@ -415,6 +415,30 @@ bw_profile <- function(bwfiles,
   check_filelist(bwfiles)
   check_filelist(bedfile)
   gr <- rtracklayer::import(bedfile)
+
+  if (bin <= 0) {
+    stop(paste('bin size must be a positive value:', bin))
+  }
+
+  if (upstream <= 0) {
+    stop(paste('upstream size must be a positive value:', upstream))
+  }
+
+  if (downstream <= 0) {
+    stop(paste('downstream size must be a positive value:', downstream))
+  }
+
+  if (bin > upstream || bin > downstream) {
+    stop('bin size must be smaller than flanking regions')
+  }
+
+  if (is.null(colnames)) {
+    colnames <- basename(bwfiles)
+  }
+
+  if (length(bwfiles) != length(colnames)) {
+    stop('colnames and bwfiles must have the same length')
+  }
 
   values_list <- purrr::map2(bwfiles,
                              colnames,

--- a/elsasserlib/man/bw_profile.Rd
+++ b/elsasserlib/man/bw_profile.Rd
@@ -7,7 +7,7 @@
 bw_profile(
   bwfiles,
   bedfile,
-  colnames,
+  colnames = NULL,
   mode = "stretch",
   bin = 100,
   upstream = 2500,

--- a/elsasserlib/tests/testthat/test_bwtools.R
+++ b/elsasserlib/tests/testthat/test_bwtools.R
@@ -266,10 +266,43 @@ test_that("bw_profile errors on non existing files on bwlist", {
 
 
 test_that("bw_profile runs quiet on valid parameters", {
-  expect_silent({values <- bw_profile(c(bw1), bed_with_names, colnames=NULL)})
+  expect_silent({values <- bw_profile(c(bw1, bw2),
+                       bed_with_names,
+                       upstream=1, downstream=1, bin=1)})
 
 })
 
+test_that("bw_profile throws error on flanking region smaller than bin size", {
+  expect_error({values <- bw_profile(c(bw1, bw2),
+                                      bed_with_names,
+                                      upstream=1, downstream=1, bin=10)},
+               "bin size must be smaller than flanking regions")
+
+})
+
+test_that("bw_profile throws error on negative bin size", {
+  expect_error({values <- bw_profile(c(bw1, bw2),
+                                     bed_with_names,
+                                     upstream=1, downstream=1, bin=-10)},
+               "bin size must be a positive value: -10")
+
+})
+
+test_that("bw_profile throws error on negative upstream value", {
+  expect_error({values <- bw_profile(c(bw1, bw2),
+                                     bed_with_names,
+                                     upstream=-10, downstream=10, bin=10)},
+               "upstream size must be a positive value: -10")
+
+})
+
+test_that("bw_profile throws error on negative downstream value", {
+  expect_error({values <- bw_profile(c(bw1, bw2),
+                                     bed_with_names,
+                                     upstream=10, downstream=-10, bin=10)},
+               "downstream size must be a positive value: -10")
+
+})
 
 test_that("bw_bed returns correct median-of-means aggregated values", {
   values <- bw_bed(bw1,


### PR DESCRIPTION
`bw_profile` function was not handling properly the `colnames` parameter when it was not `NULL`.

Additional tests on parameters (`bin`, `upstream`, `downstream`) are also added.