### PR TITLE
Stats can return GRanges objects

### DIFF
--- a/elsasserlib/man/bw_bed_diff_analysis.Rd
+++ b/elsasserlib/man/bw_bed_diff_analysis.Rd
@@ -10,7 +10,8 @@ bw_bed_diff_analysis(
   bedfile,
   label_c1,
   label_c2,
-  estimate_size_factors = FALSE
+  estimate_size_factors = FALSE,
+  as_granges = FALSE
 )
 }
 \arguments{
@@ -26,6 +27,9 @@ bw_bed_diff_analysis(
 
 \item{estimate_size_factors}{If TRUE, normal DESeq2 procedure is done. Set it
 to true to analyze non-MINUTE data.}
+
+\item{as_granges}{If TRUE, returns a GRanges object. This is useful when
+loci coordinates are relevant.}
 }
 \value{
 a DESeqResults object as returned by DESeq2::results function

--- a/elsasserlib/man/bw_bins_diff_analysis.Rd
+++ b/elsasserlib/man/bw_bins_diff_analysis.Rd
@@ -11,7 +11,8 @@ bw_bins_diff_analysis(
   label_c2,
   bin_size = 10000,
   genome = "mm9",
-  estimate_size_factors = FALSE
+  estimate_size_factors = FALSE,
+  as_granges = FALSE
 )
 }
 \arguments{
@@ -29,6 +30,9 @@ bw_bins_diff_analysis(
 
 \item{estimate_size_factors}{If TRUE, normal DESeq2 procedure is done. Set it
 to true to analyze non-MINUTE data.}
+
+\item{as_granges}{If TRUE, returns a GRanges object. This is useful when
+loci coordinates are relevant.}
 }
 \value{
 a DESeqResults object as returned by DESeq2::results function

--- a/elsasserlib/man/bw_granges_diff_analysis.Rd
+++ b/elsasserlib/man/bw_granges_diff_analysis.Rd
@@ -9,14 +9,15 @@ bw_granges_diff_analysis(
   granges_c2,
   label_c1,
   label_c2,
-  estimate_size_factors = FALSE
+  estimate_size_factors = FALSE,
+  as_granges = FALSE
 )
 }
 \arguments{
 \item{granges_c1}{GRanges object containing the values for condition 1.}
 
 \item{granges_c2}{GRanges object containing the values for condition 2.
-Note that these objects must correspond to the same loci.}
+Note that these objects MUST CORRESPOND to the same loci.}
 
 \item{label_c1}{Condition name for condition 1.}
 
@@ -24,9 +25,13 @@ Note that these objects must correspond to the same loci.}
 
 \item{estimate_size_factors}{If TRUE, normal DESeq2 procedure is done. Set it
 to true to analyze non-MINUTE data.}
+
+\item{as_granges}{If TRUE, returns a GRanges object. This is useful when
+loci coordinates are relevant.}
 }
 \value{
-a DESeqResults object as returned by DESeq2::results function
+a DESeqResults object as returned by DESeq2::results function. A GRanges object
+    if as_granges parameter is TRUE.
 }
 \description{
 Runs a DESeq2 analysis on loci specified on GRanges objects.

--- a/elsasserlib/tests/testthat/test_bwstats.R
+++ b/elsasserlib/tests/testthat/test_bwstats.R
@@ -38,7 +38,8 @@ test_that("bw_bins_diff_analysis passes on parameters", {
                                        bins_c2,
                                        label_c1,
                                        label_c2,
-                                       estimate_size_factors = estimate_size_factors)
+                                       estimate_size_factors = estimate_size_factors,
+                                       as_granges = as_granges)
   )
 
   expect_call(m_bins, 1,
@@ -54,7 +55,8 @@ test_that("bw_bins_diff_analysis passes on parameters", {
               granges_c2 = reduced_bg_bins,
               label_c1 = "treated",
               label_c2 = "untreated",
-              estimate_size_factors = FALSE)
+              estimate_size_factors = FALSE,
+              as_granges = FALSE)
 
   expect_args(m_bins, 1,
               c(bw1, bw2),
@@ -74,14 +76,15 @@ test_that("bw_bed_diff_analysis passes on parameters", {
   with_mock(
     bw_granges_diff_analysis = m_func,
     bw_bed = m_bed,
-    bw_bed_diff_analysis(c(bw1, bw2), bg_bw, bed, "treated", "untreated")
+    bw_bed_diff_analysis(c(bw1, bw2), bg_bw, bed, "treated", "untreated", as_granges = TRUE)
   )
   expect_call(m_func, 1,
               bw_granges_diff_analysis(loci_c1,
                                        loci_c2,
                                        label_c1,
                                        label_c2,
-                                       estimate_size_factors = estimate_size_factors)
+                                       estimate_size_factors = estimate_size_factors,
+                                       as_granges = as_granges)
   )
 
   expect_call(m_bed, 1,
@@ -97,7 +100,8 @@ test_that("bw_bed_diff_analysis passes on parameters", {
               granges_c2 = reduced_bg_bins,
               label_c1 = "treated",
               label_c2 = "untreated",
-              estimate_size_factors = FALSE)
+              estimate_size_factors = FALSE,
+              as_granges = TRUE)
 
   expect_args(m_bed, 1,
               c(bw1, bw2),


### PR DESCRIPTION
I have added a parameter `as_granges` to the stats functions that make use of `DESeq2`. Before, the results table lost locus information, so it was difficult to integrate this with other sources of data. It is also interesting to export significant bins or annotations to another file.

